### PR TITLE
Bug fix in put

### DIFF
--- a/lib/promiseSftp.coffee
+++ b/lib/promiseSftp.coffee
@@ -308,7 +308,7 @@ class PromiseSftp
       .then (stream) ->
         if input instanceof Buffer
           return stream.end(input)
-        stream.pipe(input)
+        input.pipe(stream)
         undefined
 
     @append = (input, destPath) ->


### PR DESCRIPTION
If using a readableStream for a put operation, it would fail with:
```
Tue, 28 Jun 2016 12:20:13 GMT ringr:enterpriseApiCtrl 	name:         Error
	message:      Cannot pipe. Not readable.
	stack:        Error: Cannot pipe. Not readable.
    at WriteStream.Writable.pipe (_stream_writable.js:161:22)
    at /data/ringr-api/node_modules/promise-sftp/dist/promiseSftp.js:368:20
```

This was due to trying to pipe the writableStream into the readableStream:
```
stream.pipe(input);
```
reversed that and its fine:
```
input.pipe(stream)
```