### PR TITLE
Allow options to be passed to `get()`

### DIFF
--- a/lib/promiseSftp.coffee
+++ b/lib/promiseSftp.coffee
@@ -295,9 +295,8 @@ class PromiseSftp
           group: file.attrs.gid
           target: null   # TODO
           sticky: null   # TODO
-    
-    @get = (sourcePath, opts) -> Promise.try () ->
-      options = opts || {}
+
+    @get = (sourcePath, options = {}) -> Promise.try () ->
       if restartOffset != null
         options.start = restartOffset
         options.flags = 'r+'

--- a/lib/promiseSftp.coffee
+++ b/lib/promiseSftp.coffee
@@ -298,8 +298,8 @@ class PromiseSftp
 
     @get = (sourcePath, options = {}) -> Promise.try () ->
       if restartOffset != null
-        options.start = restartOffset
-        options.flags = 'r+'
+        options.start = options.start || restartOffset
+        options.flags = options.flags || 'r+'
         restartOffset = null
       promisifiedClientMethods.createReadStream(sourcePath, options)
       .then (stream) ->

--- a/lib/promiseSftp.coffee
+++ b/lib/promiseSftp.coffee
@@ -296,11 +296,11 @@ class PromiseSftp
           target: null   # TODO
           sticky: null   # TODO
     
-    @get = (sourcePath) -> Promise.try () ->
+    @get = (sourcePath, opts) -> Promise.try () ->
+      options = opts || {}
       if restartOffset != null
-        options =
-          start: restartOffset
-          flags: 'r+'
+        options.start = restartOffset
+        options.flags = 'r+'
         restartOffset = null
       promisifiedClientMethods.createReadStream(sourcePath, options)
       .then (stream) ->

--- a/package.json
+++ b/package.json
@@ -1,26 +1,17 @@
 {
-  "name": "promise-sftp",
-  "description": "a promise-based sftp client for node.js",
+  "name": "@symbiont-io/promise-sftp",
+  "description": "a fork of a promise-based sftp client for node.js",
   "version": "0.10.0",
   "main": "index.js",
-  "author": "RealtyMaps",
-  "contributors": [
-    "Joe Ibershoff <joe@realtymaps.com>"
-  ],
+  "author": "Jacob Romer",
   "files": [
     "dist",
     "index.js"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/realtymaps/promise-sftp"
+    "url": "https://github.com/symbiont-io/promise-sftp"
   },
-  "keywords": [
-    "sftp",
-    "client",
-    "promise",
-    "node"
-  ],
   "dependencies": {
     "bluebird": "2.x",
     "promise-ftp-common": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,26 @@
 {
-  "name": "@symbiont-io/promise-sftp",
-  "description": "a fork of a promise-based sftp client for node.js",
+  "name": "promise-sftp",
+  "description": "a promise-based sftp client for node.js",
   "version": "0.10.0",
   "main": "index.js",
-  "author": "Jacob Romer",
+  "author": "RealtyMaps",
+  "contributors": [
+    "Joe Ibershoff <joe@realtymaps.com>"
+  ],
   "files": [
     "dist",
     "index.js"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/symbiont-io/promise-sftp"
+    "url": "https://github.com/realtymaps/promise-sftp"
   },
+  "keywords": [
+    "sftp",
+    "client",
+    "promise",
+    "node"
+  ],
   "dependencies": {
     "bluebird": "2.x",
     "promise-ftp-common": "^1.1.2",
@@ -32,7 +41,7 @@
     "iojs": "*"
   },
   "scripts": {
-    "prepare": "coffee --compile --output dist/ lib/",
+    "prepublish": "coffee --compile --output dist/ lib/",
     "dev": "coffee --watch --output dist lib/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "iojs": "*"
   },
   "scripts": {
-    "prepublish": "coffee --compile --output dist/ lib/",
+    "prepare": "coffee --compile --output dist/ lib/",
     "dev": "coffee --watch --output dist lib/"
   }
 }


### PR DESCRIPTION
This is needed for SFTP downloads that hit this issue: https://github.com/mscdex/ssh2-streams/issues/43