### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
   "devDependencies": {
     "coffee-script": "1.x"
   },
-  "peerDependencies": {
-    "promise-ftp-common": "^1.1.2"
-  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/realtymaps/promise-sftp/issues"


### PR DESCRIPTION
Is  peerDependencies: promise-ftp-common really needed when it is already a dependency? It gives us warnings during yarn install.